### PR TITLE
fix: 修复可能出现的GetTransform返回false但error_code为0的问题。

### DIFF
--- a/cvAutoTrack/AutoTrack.cpp
+++ b/cvAutoTrack/AutoTrack.cpp
@@ -76,20 +76,27 @@ bool AutoTrack::uninit()
 bool AutoTrack::GetTransform(float & x, float & y, float & a)
 {
 	double x2 = 0, y2 = 0, a2 = 0;
-	bool PositionState = GetPosition(x2, y2);
-	bool DirectionState= GetDirection(a2);
 	if (!is_init_end)
 	{
 		init();//初始化
 	}
-	if (DirectionState && PositionState)
+
+	/*
+	分别判断是否成功获取，避免前一个error_code被后一个error_code覆盖
+	而导致本函数返回false（表示失败）但error_code为0（表示成功）。
+	*/
+	if (!GetPosition(x2, y2))
 	{
-		x = (float)x2;
-		y = (float)y2;
-		a = (float)a2;
-		return true;
+		return false;
 	}
-	return false;
+	if (!GetDirection(a2))
+	{
+		return false;
+	}
+	x = (float)x2;
+	y = (float)y2;
+	a = (float)a2;
+	return true;
 }
 
 bool AutoTrack::GetPosition(double & x, double & y)


### PR DESCRIPTION
`GetTransform` 实际上调用了 `GetPosition` 和 `GetDirection` 两个函数，这两个函数不论成功与否都会设置 `error_code` ，而原代码是同时调用这两个函数，并用 `&&` 求出最终是否成功。

这样会产生一种可能，那就是 `GetPosition` 失败了，将 `error_code` 设置为非0值，而 `GetDirection` 成功了，用 `0` 覆盖了原先的 `error_code` ，导致最后 `false && true` 返回 `false` ，但 `error_code` 值并没有指示 `GetPosition` 的失败原因。
