### PR TITLE
添加其它语言调用示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,35 @@
 
 一个通过opencv图像匹配算法，从原神客户端中获取角色在地图上的位置的DLL动态链接库。
 
-该dll使用源自窗口截图的游戏画面进行图像处理算法实现，不会对游戏内存进行读写，不会有封号的风险，因而效果也具备一定的局限性。
-
 [![Build status](https://ci.appveyor.com/api/projects/status/1q2jfn373bc15raa?svg=true)](https://ci.appveyor.com/project/GengGode/genshinimpact-autotrack-dll) ![convention](https://img.shields.io/badge/convention-__cdecl-orange.svg) ![platform](https://img.shields.io/badge/platform-Windows-blue.svg) ![](https://img.shields.io/badge/cpu-AMD64-purple.svg)
 
-## 使用
+## 如何使用
 
-编译文件下载链接：
+1. 下载编译好的动态链接库。
+   - https://pan.baidu.com/s/1y-lgkGiyIJPa3_y0aRlOnQ（提取码：e7zv）
+   - https://github.com/GengGode/GenshinImpact_AutoTrack_DLL/releases/
+2. 装载动态链接库后，根据[函数手册](#函数手册)对相关函数进行调用或封装。
+3. 部分语言的调用可参见 `impl` 文件夹内的调用示例。
 
-- 国内：https://pan.baidu.com/s/1y-lgkGiyIJPa3_y0aRlOnQ（提取码：e7zv）
-- 国外：https://github.com/GengGode/GenshinImpact_AutoTrack_DLL/releases/
+## 注意事项
 
-目前只编译了 Windows x64 平台上的动态链接库（.dll），对于其它平台，如 Windows x86（.dll）或 Linux 平台（.so），需要下载源代码另行编译。
+- 目前只编译了 Windows x64 平台上的动态链接库（.dll），对于 Windows x86 或其它平台，如 Linux 平台（.so），需要下载源代码另行编译。
+- Windows 规定 64位 进程/DLL与 32位 进程/DLL之间不能相互调用/加载，因此调用动态链接库前，请务必确保调用进程是 **64位进程** 。
+- 本项目借游戏画面的窗口截图进行图像处理算法以实现所有功能，其不会对游戏内存进行读写，因而不会有封号的风险，但效果也因此具备一定的局限。
+- 项目仅在有限的条件下测试过，如需排查错误，强烈建议按照以下描述进行环境配置。
+  - 原神客户端 > 右上角派蒙 > 设置 > 抗锯齿，设置为 `SMAA`
+  - 原神客户端 > 右上角派蒙 > 设置 > 分辨率，设置为 `1920x1080`
 
-Windows 规定 64位进程/DLL 与 32位进程/DLL 不能相互调用（但可以相互通信），因而动态链接库的调用方也须是 **64位进程** 。
+## 对于开发者
 
-## 原神要求
-
-目前想要准确无误的正常运行，需要以下两点：
-
-- 原神设置 > 抗锯齿：SAMM
-- 原神设置 > 分辨率：1920x1080
-
-以上是确保能够正常运行的因素，其他情况下不保证能够正常得到结果。
-
-## 其它仓库位置
-
-- gitee：[https://gitee.com/Yu_Sui_Xian/yuanshen-auto-tracking-dll](https://gitee.com/Yu_Sui_Xian/yuanshen-auto-tracking-dll)
+- 码云上的仓库：[https://gitee.com/Yu_Sui_Xian/yuanshen-auto-tracking-dll](https://gitee.com/Yu_Sui_Xian/yuanshen-auto-tracking-dll)
 
 
 ## 项目结构
 
 - **cvAutoTrack**，dll工程
 - **cvAT_dllTest**，C++下调用dll的测试工程
+- **impl**，部分语言的调用示例。
 
 
 # 函数手册

--- a/impl/Python/main.py
+++ b/impl/Python/main.py
@@ -1,0 +1,77 @@
+from ctypes import *
+from time import sleep
+
+
+class AutoTracker:
+    def __init__(self, dll_path: str):
+        self.__lib = CDLL(dll_path)
+
+        # bool init();
+        self.__lib.init.restype = c_bool
+
+        # bool uninit();
+        self.__lib.uninit.restype = c_bool
+
+        # bool SetHandle(long long int handle);
+        self.__lib.SetHandle.argtypes = [c_longlong]
+        self.__lib.SetHandle.restype = c_bool
+
+        # bool GetTransform(float &x, float &y, float &a);
+        self.__lib.GetTransform.argtypes = [POINTER(c_float), POINTER(c_float), POINTER(c_float)]
+        self.__lib.GetTransform.restype = c_bool
+
+        # bool GetPosition(double & x, double & y);
+        self.__lib.GetPosition.argtypes = []
+        self.__lib.GetPosition.restype = c_bool
+
+        # bool GetDirection(double &a);
+        self.__lib.GetDirection.argtypes = [POINTER(c_double)]
+        self.__lib.GetDirection.restype = c_bool
+
+        # bool GetUID(int &uid);
+        self.__lib.GetUID.argtypes = [POINTER(c_int)]
+        self.__lib.GetUID.restype = c_bool
+
+    def init(self) -> bool:
+        return self.__lib.init()
+
+    def uninit(self) -> bool:
+        return self.__lib.uninit()
+
+    def get_last_error(self) -> int:
+        return self.__lib.GetLastErr()
+
+    def set_handle(self, hwnd: int) -> bool:
+        return self.__lib.SetHandle(hwnd)
+
+    def get_transform(self) -> (bool, float, float, float):
+        x, y, a = c_float(0), c_float(0), c_float(0)
+        ret = self.__lib.GetTransform(x, y, a)
+        return ret, x.value, y.value, a.value
+
+    def get_position(self) -> (bool, float, float):
+        x, y = c_float(0), c_float(0)
+        ret = self.__lib.GetPosition(x, y)
+        return ret, x.value, y.value
+
+    def get_direction(self) -> (bool, float):
+        a = c_float(0)
+        ret = self.__lib.GetDirection(a)
+        return ret, a.value
+
+    def get_uid(self) -> (bool, int):
+        uid = c_int(0)
+        ret = self.__lib.GetUID(uid)
+        return ret, uid.value
+
+
+if __name__ == '__main__':
+    sleep(5)
+    tracker = AutoTracker(r'./CVAUTOTRACK.dll')
+    tracker.init()
+    print('1) err', tracker.get_last_error(), '\n')
+    print(tracker.get_transform())
+    print('2) err', tracker.get_last_error(), '\n')
+    print(tracker.get_uid())
+    print('3) err', tracker.get_last_error(), '\n')
+    tracker.uninit()


### PR DESCRIPTION
1. 添加了使用 Python 调用DLL的示例。
2. 在 README 中添加对多语言调用示例的说明。
3. 整理了一下其它说明，整合为 `注意事项` 。